### PR TITLE
update readme to include fontconfig dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - curl
 - unzip
 - fzf
+- fontconfig
 
 ### Installation
 


### PR DESCRIPTION
Tried to run this on OSX, I needed fontconfig to provide the fc-list command. I think this will be the same on linux as well