### PR TITLE
Update README.md about curl version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Dependencies
 
-- curl
+- curl >= 7.73.0
 - unzip
 - fzf
 - fontconfig


### PR DESCRIPTION
Since the curl `--output-dir` option was introduced in version 7.73.0,
older versions can't use the `getnf` script.