### PR TITLE
feat: update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ mkdir -p "$DEST"
 
 if [ -n "$CURL_COMMAND" ]; then
     #  if the script was invoked by curl
+    rm -f "$GETNFLOC"
 
     # -f: fail fast with no output at all on server errors
     # -s: be silent


### PR DESCRIPTION
This PR updates the install script, allowing both the current installation method with
```
git clone https://github.com/ronniedroid/getnf.git
cd getnf
./install.sh
```
and the remote installation using
```
bash <(curl -fsSL https://raw.githubusercontent.com/ronniedroid/getnf/master/install.sh)
```
The current installation method is left there to not cause any breaking changes, but can be removed later.
This should close #20 