### PR TITLE
fix(install): switch to using `curl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,13 @@
 bash <(curl -fsSL https://raw.githubusercontent.com/ronniedroid/getnf/master/install.sh)
 ```
 
-or
-
-```
-git clone https://github.com/ronniedroid/getnf.git
-cd getnf
-./install.sh
-```
-
-Make sure that `~/.local/bin` is in your PATH
+Make sure that `~/.local/bin` is in your PATH.
 
 ### Usage
 
-run `getnf -h` to get a help message.
+Run `getnf -h` to get a help message.
 
-- run `getnf` from the terminal and it will represent you with a list of Nerd Fonts,
+- run `getnf` from the terminal and it will present you with a list of Nerd Fonts
 - choose one or more fonts (by index/number) to install
 - hit Return/Enter to install the selected fonts
 - type the index/number corresponding to 'Quit' to cancel

--- a/install.sh
+++ b/install.sh
@@ -6,16 +6,11 @@ GETNFLOC="$DEST/getnf"
 # -p will not error if the directory already exists
 mkdir -p "$DEST"
 
-if [ -n "$CURL_COMMAND" ]; then
-    #  if the script was invoked by curl
-    rm -f "$GETNFLOC"
+rm -f "$GETNFLOC"
 
-    # -f: fail fast with no output at all on server errors
-    # -s: be silent
-    # -S: but show an error message if it fails
-    # -L: follow redirects
-    # -O: write output to a local file named like the remote file
-    curl -fsSLO https://raw.githubusercontent.com/ronniedroid/getnf/master/getnf --output-dir "$DEST"
-else
-    cp --remove-destination "$(pwd)/getnf" "$GETNFLOC"
-fi
+# -f: fail fast with no output at all on server errors
+# -s: be silent
+# -S: but show an error message if it fails
+# -L: follow redirects
+# -O: write output to a local file named like the remote file
+curl -fsSLO https://raw.githubusercontent.com/ronniedroid/getnf/master/getnf --output-dir "$DEST"

--- a/install.sh
+++ b/install.sh
@@ -14,3 +14,6 @@ rm -f "$GETNFLOC"
 # -L: follow redirects
 # -O: write output to a local file named like the remote file
 curl -fsSLO https://raw.githubusercontent.com/ronniedroid/getnf/master/getnf --output-dir "$DEST"
+
+# make the script executable
+chmod 755 "$GETNFLOC"


### PR DESCRIPTION
Apparently ChatGPT lied to me and there's now way to detect if a script was called using `curl`. This will switch to just using `curl` inside `install.sh` everytime. It'll still work with
```
git clone https://github.com/ronniedroid/getnf.git
cd getnf
./install.sh
```
but I'd remove this part from the README.