### PR TITLE
feat: show progress during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ unless there is a new version of Nerd Fonts.
 You can force reinstalling a font by using the `-f` flag.
 
 Enjoy!
+
+### Notes
+
+You can suppress the installation output with a flag `--silent` or `-s`:
+```
+curl -fsSL https://raw.githubusercontent.com/ronniedroid/getnf/master/install.sh | sh -s -- --silent
+```

--- a/install.sh
+++ b/install.sh
@@ -3,17 +3,15 @@
 DEST="$HOME/.local/bin"
 GETNFLOC="$DEST/getnf"
 
-# -p will not error if the directory already exists
+GREEN=$(tput setaf 2)
+BLUE=$(tput setaf 4)
+RESET=$(tput sgr0)
+
+echo "${BLUE}Installing getnf...${RESET}"
+
 mkdir -p "$DEST"
-
 rm -f "$GETNFLOC"
-
-# -f: fail fast with no output at all on server errors
-# -s: be silent
-# -S: but show an error message if it fails
-# -L: follow redirects
-# -O: write output to a local file named like the remote file
-curl -fsSLO https://raw.githubusercontent.com/ronniedroid/getnf/master/getnf --output-dir "$DEST"
-
-# make the script executable
+curl -fLO# https://raw.githubusercontent.com/ronniedroid/getnf/master/getnf --output-dir "$DEST"
 chmod 755 "$GETNFLOC"
+
+echo "${GREEN}Installation finished${RESET}"

--- a/install.sh
+++ b/install.sh
@@ -7,11 +7,20 @@ GREEN=$(tput setaf 2)
 BLUE=$(tput setaf 4)
 RESET=$(tput sgr0)
 
-echo "${BLUE}Installing getnf...${RESET}"
+# add the -s or --silent flag to suppress output
+SILENT=$([[ "$1" == "-s" ]] || [[ "$1" == "--silent" ]] && echo true || echo false)
+
+$SILENT || echo "${BLUE}Installing getnf...${RESET}"
 
 mkdir -p "$DEST"
 rm -f "$GETNFLOC"
-curl -fLO# https://raw.githubusercontent.com/ronniedroid/getnf/master/getnf --output-dir "$DEST"
+
+if $SILENT; then
+    curl -fsSLO https://raw.githubusercontent.com/ronniedroid/getnf/master/getnf --output-dir "$DEST"
+else
+    curl -fLO# https://raw.githubusercontent.com/ronniedroid/getnf/master/getnf --output-dir "$DEST"
+fi
+
 chmod 755 "$GETNFLOC"
 
-echo "${GREEN}Installation finished${RESET}"
+$SILENT || echo "${GREEN}Installation finished${RESET}"


### PR DESCRIPTION
I added some feedback during installation. But I also added a flag to suppress that feedback if needed. Before merging you can test the normal install with
```
curl -fsSL https://raw.githubusercontent.com/trimclain/getnf/interactive-install/install.sh | sh
```
and the silent flag with
```
curl -fsSL https://raw.githubusercontent.com/trimclain/getnf/interactive-install/install.sh | sh -s -- --silent
```
I also decided that the info about the silent flag would look better in the `Notes` section to make the install section contain only the most important information. But feel free to request any changes.