### PR TITLE
Update Dockerfile to Multi-Stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM ubuntu:latest
+### Build stage
+FROM ubuntu:latest AS builder
 RUN apt update && apt install -y sudo vim curl fzf fontconfig xz-utils
 RUN useradd -m tester && echo "tester:pass" | chpasswd && usermod -aG sudo tester && chown -R tester:tester /home/tester
 USER tester
 RUN echo 'export PATH=$HOME/.local/bin:$PATH' > /home/tester/.bash_aliases
 RUN mkdir -p /home/tester/.local/bin/
 COPY --chown=tester:tester ./getnf /home/tester/.local/bin/getnf
+### Runtime stage
+FROM ubuntu:latest
+COPY --from=builder /home/tester/.local/bin/getnf /home/tester/.local/bin/getnf
 WORKDIR /home/tester
 CMD ["/bin/bash"]


### PR DESCRIPTION
Hi,

Thanks for maintaining getnf. I represent a research group investigating [multi-stage builds](https://docs.docker.com/build/building/multi-stage/). We recently refactored your Dockerfile to a multi-stage Dockerfile and found that it brings the following benefits: 

✅ Reduced final image size (from 204MB to 75MB)  
✅ Minimized image vulnerabilities (verified via [Trivy](https://github.com/aquasecurity/trivy), from 30 to 16)  

We hope this small improvement to the Dockerfile will be useful to you :)

Thanks,